### PR TITLE
Fix Go version for html2md dependency

### DIFF
--- a/.github/workflows/diff-checker.yml
+++ b/.github/workflows/diff-checker.yml
@@ -12,6 +12,8 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v5
+        with:
+          go-version: 1.23
 
       - name: Check diff
         id: check-diff


### PR DESCRIPTION
html2md's depending package requres go >= 1.23.

```shell
go: downloading github.com/suntong/html2md v1.5.0
go: finding module for package github.com/mkideal/cli
go: finding module for package github.com/JohannesKaufmann/html-to-markdown/plugin
go: finding module for package github.com/PuerkitoBio/goquery
go: finding module for package github.com/JohannesKaufmann/html-to-markdown
go: downloading github.com/PuerkitoBio/goquery v1.10.0
go: finding module for package github.com/mkideal/cli/clis
go: downloading github.com/JohannesKaufmann/html-to-markdown v1.6.0
go: finding module for package github.com/mkideal/cli/ext
go: downloading github.com/mkideal/cli v0.2.[7](https://github.com/toshi0607/Go-FAQ-Japanese-Edition/actions/runs/10755055397/job/29826321512#step:4:8)
go: toolchain upgrade needed to resolve github.com/PuerkitoBio/goquery
go: github.com/PuerkitoBio/goquery@v1.10.0 requires go >= 1.23 (running go 1.21.13)
Error: Process completed with exit code 1.
```

https://github.com/toshi0607/Go-FAQ-Japanese-Edition/actions/runs/10755055397/job/29826321512